### PR TITLE
Add node modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/


### PR DESCRIPTION
This is so that node_modules wont be tracked when installing dependencies locally in this repo
* Adds node_modules to gitignore