### PR TITLE
[Test/add tests][RE-MERGE->DEVELOP] Add tests for genBorromean and MLSAG_gen

### DIFF
--- a/cryptonote_utils/cryptonote_utils.js
+++ b/cryptonote_utils/cryptonote_utils.js
@@ -1378,7 +1378,13 @@ var cnUtil = function(currencyConfig) {
 	//	 thus this proves that "amount" is in [0, s^n] (we assume s to be 4) (2 for now with v2 txes)
 	//	 mask is a such that C = aG + bH, and b = amount
 	//commitMaskObj = {C: commit, mask: mask}
-	this.proveRange = function(commitMaskObj, amount, nrings) {
+	this.proveRange = function(
+		commitMaskObj,
+		amount,
+		nrings,
+		enc_seed,
+		exponent,
+	) {
 		var size = 2;
 		var C = I; //identity
 		var mask = Z; //zero scalar

--- a/cryptonote_utils/cryptonote_utils.js
+++ b/cryptonote_utils/cryptonote_utils.js
@@ -222,6 +222,7 @@ var cnUtil = function(currencyConfig) {
 
 	//for most uses you'll also want to swapEndian after conversion
 	//mainly to convert integer "scalars" to usable hexadecimal strings
+	//uint long long to 32 byte key
 	function d2h(integer) {
 		if (typeof integer !== "string" && integer.toString().length > 15) {
 			throw "integer should be entered as a string for precision";
@@ -237,12 +238,14 @@ var cnUtil = function(currencyConfig) {
 				.toLowerCase()
 		).slice(-64);
 	}
+	this.d2h = d2h;
 
 	//integer (string) to scalar
 	function d2s(integer) {
 		return swapEndian(d2h(integer));
 	}
 
+	this.d2s = d2s;
 	//scalar to integer (string)
 	function s2d(scalar) {
 		return JSBigInt.parse(swapEndian(scalar), 16).toString();

--- a/package.json
+++ b/package.json
@@ -38,9 +38,11 @@
     "jest": "^23.1.0"
   },
   "jest" : {
+    "testEnvironment":"node",
     "coveragePathIgnorePatterns": [
       "node_modules", 
       "cryptonote_utils/biginteger.js",
+      "cryptonote_utils/nacl-fast-cn.js",
       "cryptonote_utils/sha3.js",
       "cryptonote_utils/cryptonote_crypto_EMSCRIPTEN.js"]
   }

--- a/tests/MG_sigs.spec.js
+++ b/tests/MG_sigs.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/tests/MG_sigs.spec.js
+++ b/tests/MG_sigs.spec.js
@@ -1,0 +1,86 @@
+const monero_utils = require("../").monero_utils;
+
+it("MG_sigs", () => {
+	function skvGen(len) {
+		let skVec = [];
+		for (let i = 0; i < len; i++) {
+			skVec.push(monero_utils.skGen());
+		}
+		return skVec;
+	}
+	//initializes a key matrix;
+	//first parameter is rows,
+	//second is columns
+	function keyMInit(rows, cols) {
+		let rv = [];
+		for (let i = 0; i < cols; i++) {
+			rv.push([]);
+		}
+		return rv;
+	}
+	let j = 0;
+
+	//Tests for MG Sigs
+	//#MG sig: true one
+	let N = 3; // cols
+	let R = 2; // rows
+
+	let xtmp = skvGen(R);
+	let xm = keyMInit(R, N); // = [[None]*N] #just used to generate test public keys
+	let sk = skvGen(R);
+
+	// [
+	// [pubkey1, commitment1],
+	// [pubkey2, commitment2],
+	// ...
+	// [pubkeyn, commitmentn]]
+	// // Gen creates a signature which proves that for some column in the keymatrix "pk"
+	//  the signer knows a secret key for each row in that column
+	let P = keyMInit(R, N); // = keyM[[None]*N] #stores the public keys;
+
+	let ind = 2;
+	let i = 0;
+
+	for (j = 0; j < R; j++) {
+		for (i = 0; i < N; i++) {
+			xm[i][j] = monero_utils.skGen();
+			P[i][j] = monero_utils.ge_scalarmult_base(xm[i][j]); // generate fake [pubkey, commit]
+		}
+	}
+
+	for (j = 0; j < R; j++) {
+		// our secret vector of [onetimesec, z]
+		sk[j] = xm[ind][j];
+	}
+
+	let message = monero_utils.identity();
+	let kimg = monero_utils.ge_scalarmult(
+		monero_utils.hashToPoint(P[ind][0]),
+		sk[0],
+	);
+	let rv = monero_utils.MLSAG_Gen(message, P, sk, kimg, ind);
+	let c = monero_utils.MLSAG_ver(message, P, rv, kimg);
+
+	expect(Number(c)).toEqual(0);
+
+	xtmp = skvGen(R);
+	xm = keyMInit(R, N); // = [[None]*N] #just used to generate test public keys
+	sk = skvGen(R);
+
+	for (j = 0; j < R; j++) {
+		for (i = 0; i < N; i++) {
+			xm[i][j] = monero_utils.skGen();
+			P[i][j] = monero_utils.ge_scalarmult_base(xm[i][j]); // generate fake [pubkey, commit]
+		}
+	}
+
+	sk[1] = skGen(); //assume we don't know one of the private keys..
+	kimg = monero_utils.ge_scalarmult(
+		monero_utils.hashToPoint(P[ind][0]),
+		sk[0],
+	);
+	rv = monero_utils.MLSAG_Gen(message, P, sk, kimg, ind);
+	c = monero_utils.MLSAG_ver(message, P, rv, kimg);
+
+	expect(Number(c)).toBeFalsy();
+});

--- a/tests/MG_sigs.spec.js
+++ b/tests/MG_sigs.spec.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 const monero_utils = require("../").monero_utils;
 
 it("MG_sigs", () => {

--- a/tests/borromean/borromean_1.spec.js
+++ b/tests/borromean/borromean_1.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/tests/borromean/borromean_1.spec.js
+++ b/tests/borromean/borromean_1.spec.js
@@ -1,0 +1,10 @@
+const monero_utils = require("../../").monero_utils;
+const { generate_parameters } = require("./test_parameters");
+const { indi, P1v, P2v, xv, N } = generate_parameters();
+
+it("borromean_3", () => {
+	// #true one
+	const bb = monero_utils.genBorromean(xv, [P1v, P2v], indi, 2, N); /*?.*/
+	const valid = monero_utils.verifyBorromean(bb, P1v, P2v); /*?.*/
+	expect(valid).toBe(true);
+});

--- a/tests/borromean/borromean_1.spec.js
+++ b/tests/borromean/borromean_1.spec.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 const monero_utils = require("../../").monero_utils;
 const { generate_parameters } = require("./test_parameters");
 const { indi, P1v, P2v, xv, N } = generate_parameters();

--- a/tests/borromean/borromean_2.spec.js
+++ b/tests/borromean/borromean_2.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/tests/borromean/borromean_2.spec.js
+++ b/tests/borromean/borromean_2.spec.js
@@ -1,0 +1,11 @@
+const monero_utils = require("../../").monero_utils;
+const { generate_parameters } = require("./test_parameters");
+const { indi, P1v, P2v, xv, N } = generate_parameters();
+
+it("borromean_2", () => {
+	//#false one
+	indi[3] = `${(+indi[3] + 1) % 2}`;
+	const bb = monero_utils.genBorromean(xv, [P1v, P2v], indi, 2, N); /*?.*/
+	const valid = monero_utils.verifyBorromean(bb, P1v, P2v); /*?.*/
+	expect(valid).toBe(false);
+});

--- a/tests/borromean/borromean_2.spec.js
+++ b/tests/borromean/borromean_2.spec.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 const monero_utils = require("../../").monero_utils;
 const { generate_parameters } = require("./test_parameters");
 const { indi, P1v, P2v, xv, N } = generate_parameters();

--- a/tests/borromean/borromean_3.spec.js
+++ b/tests/borromean/borromean_3.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/tests/borromean/borromean_3.spec.js
+++ b/tests/borromean/borromean_3.spec.js
@@ -1,0 +1,13 @@
+const monero_utils = require("../../").monero_utils;
+const { generate_parameters } = require("./test_parameters");
+const { indi, P1v, P2v, xv, N } = generate_parameters();
+
+it("borromean_3", () => {
+	//#true one again
+	indi[3] = `${(+indi[3] + 1) % 2}`;
+	indi[3] = `${(+indi[3] + 1) % 2}`;
+
+	const bb = monero_utils.genBorromean(xv, [P1v, P2v], indi, 2, N); /*?.*/
+	const valid = monero_utils.verifyBorromean(bb, P1v, P2v); /*?.*/
+	expect(valid).toBe(true);
+});

--- a/tests/borromean/borromean_3.spec.js
+++ b/tests/borromean/borromean_3.spec.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 const monero_utils = require("../../").monero_utils;
 const { generate_parameters } = require("./test_parameters");
 const { indi, P1v, P2v, xv, N } = generate_parameters();

--- a/tests/borromean/borromean_4.spec.js
+++ b/tests/borromean/borromean_4.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/tests/borromean/borromean_4.spec.js
+++ b/tests/borromean/borromean_4.spec.js
@@ -1,0 +1,10 @@
+const monero_utils = require("../../").monero_utils;
+const { generate_parameters } = require("./test_parameters");
+const { indi, P1v, P2v, xv, N } = generate_parameters();
+
+it("borromean_4", () => {
+	// #false one
+	const bb = monero_utils.genBorromean(xv, [P2v, P1v], indi, 2, N); /*?.*/
+	const valid = monero_utils.verifyBorromean(bb, P1v, P2v); /*?.*/
+	expect(valid).toBe(false);
+});

--- a/tests/borromean/borromean_4.spec.js
+++ b/tests/borromean/borromean_4.spec.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 const monero_utils = require("../../").monero_utils;
 const { generate_parameters } = require("./test_parameters");
 const { indi, P1v, P2v, xv, N } = generate_parameters();

--- a/tests/borromean/test_parameters.js
+++ b/tests/borromean/test_parameters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/tests/borromean/test_parameters.js
+++ b/tests/borromean/test_parameters.js
@@ -1,0 +1,55 @@
+const mnemonic = require("../../cryptonote_utils/mnemonic");
+const monero_utils = require("../../").monero_utils;
+
+function randomBit() {
+	// get random 32 bits in hex
+	const rand32bits = mnemonic.mn_random(32);
+	// take 4 bits "nibble" and convert to binary
+	// then take last index
+	return monero_utils.padLeft(
+		parseInt(rand32bits[0], 16).toString(2),
+		4,
+		0,
+	)[3];
+}
+
+//Tests for Borromean signatures
+//#boro true one, false one, C != sum Ci, and one out of the range..
+const N = 64;
+let xv = [], // vector of secret keys, 1 per ring (nrings)
+	P1v = [], //key64, arr of commitments Ci
+	P2v = [], //key64
+	indi = []; // vector of secret indexes, 1 per ring (nrings), can be a string
+
+let indi_2 = [];
+let indi_3 = [];
+let indi_4 = [];
+
+let generated = false;
+
+function generate_parameters() {
+	if (generated) {
+		const indiCopy = [...indi];
+
+		return { xv, P1v, P2v, indi: indiCopy, N };
+	} else {
+		for (let j = 0; j < N; j++) {
+			indi[j] = randomBit(); /*?.*/
+
+			xv[j] = monero_utils.skGen(); /*?.*/
+
+			if (+indi[j] === 0) {
+				P1v[j] = monero_utils.ge_scalarmult_base(xv[j]); /*?.*/
+			} else {
+				P1v[j] = monero_utils.ge_scalarmult_base(xv[j]); // calculate aG = xv[j].G /*?.*/
+				P1v[j] = monero_utils.ge_add(P1v[j], monero_utils.H2[j]); // calculate aG + H2 /*?.*/
+			}
+
+			P2v[j] = monero_utils.ge_sub(P1v[j], monero_utils.H2[j]); /*?.*/
+		}
+		generated = true;
+		return { xv, P1v, P2v, indi, N };
+	}
+}
+
+module.exports = { generate_parameters };

--- a/tests/borromean/test_parameters.js
+++ b/tests/borromean/test_parameters.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 const mnemonic = require("../../cryptonote_utils/mnemonic");
 const monero_utils = require("../../").monero_utils;
 

--- a/tests/cryptonote_utils.spec.js
+++ b/tests/cryptonote_utils.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/tests/cryptonote_utils.spec.js
+++ b/tests/cryptonote_utils.spec.js
@@ -37,7 +37,7 @@ describe("cryptonote_utils tests", function() {
 		for (let j = 0; j < N; j++) {
 			indi[j] = randomBit();
 
-			xv[j] = monero_utils.random_scalar();
+			xv[j] = monero_utils.skGen();
 
 			if (+indi[j] === 0) {
 				P1v[j] = monero_utils.ge_scalarmult_base(xv[j]);
@@ -87,8 +87,8 @@ describe("cryptonote_utils tests", function() {
 		];
 
 		for (const amount of test_amounts) {
-			const k = monero_utils.random_scalar();
-			const scalar = monero_utils.random_scalar(); /*?*/
+			const k = monero_utils.skGen();
+			const scalar = monero_utils.skGen(); /*?*/
 			const amt = monero_utils.d2s(amount.toString());
 			const t0 = {
 				mask: scalar,
@@ -104,6 +104,91 @@ describe("cryptonote_utils tests", function() {
 			expect(t1.mask).toEqual(t0.mask);
 			expect(t1.amount).toEqual(t0.amount);
 		}
+	});
+
+	it("MG_sigs", () => {
+		function skvGen(len) {
+			let skVec = [];
+			for (let i = 0; i < len; i++) {
+				skVec.push(monero_utils.skGen());
+			}
+			return skVec;
+		}
+		//initializes a key matrix;
+		//first parameter is rows,
+		//second is columns
+		function keyMInit(rows, cols) {
+			let rv = [];
+			for (let i = 0; i < cols; i++) {
+				rv.push([]);
+			}
+			return rv;
+		}
+		let j = 0;
+
+		//Tests for MG Sigs
+		//#MG sig: true one
+		let N = 3; // cols
+		let R = 2; // rows
+
+		let xtmp = skvGen(R);
+		let xm = keyMInit(R, N); // = [[None]*N] #just used to generate test public keys
+		let sk = skvGen(R);
+
+		// [
+		// [pubkey1, commitment1],
+		// [pubkey2, commitment2],
+		// ...
+		// [pubkeyn, commitmentn]]
+		// // Gen creates a signature which proves that for some column in the keymatrix "pk"
+		//  the signer knows a secret key for each row in that column
+		let P = keyMInit(R, N); // = keyM[[None]*N] #stores the public keys;
+
+		let ind = 2;
+		let i = 0;
+
+		for (j = 0; j < R; j++) {
+			for (i = 0; i < N; i++) {
+				xm[i][j] = monero_utils.skGen();
+				P[i][j] = monero_utils.ge_scalarmult_base(xm[i][j]); // generate fake [pubkey, commit]
+			}
+		}
+
+		for (j = 0; j < R; j++) {
+			// our secret vector of [onetimesec, z]
+			sk[j] = xm[ind][j];
+		}
+
+		let message = monero_utils.identity();
+		let kimg = monero_utils.ge_scalarmult(
+			monero_utils.hashToPoint(P[ind][0]),
+			sk[0],
+		);
+		let rv = monero_utils.MLSAG_Gen(message, P, sk, kimg, ind);
+		let c = monero_utils.MLSAG_ver(message, P, rv, kimg);
+
+		expect(Number(c)).toEqual(0);
+
+		xtmp = skvGen(R);
+		xm = keyMInit(R, N); // = [[None]*N] #just used to generate test public keys
+		sk = skvGen(R);
+
+		for (j = 0; j < R; j++) {
+			for (i = 0; i < N; i++) {
+				xm[i][j] = monero_utils.skGen();
+				P[i][j] = monero_utils.ge_scalarmult_base(xm[i][j]); // generate fake [pubkey, commit]
+			}
+		}
+
+		sk[1] = skGen(); //assume we don't know one of the private keys..
+		kimg = monero_utils.ge_scalarmult(
+			monero_utils.hashToPoint(P[ind][0]),
+			sk[0],
+		);
+		rv = monero_utils.MLSAG_Gen(message, P, sk, kimg, ind);
+		c = monero_utils.MLSAG_ver(message, P, rv, kimg);
+
+		expect(Number(c)).toBeFalsy();
 	});
 
 	describe("old_tests", () => {

--- a/tests/cryptonote_utils.spec.js
+++ b/tests/cryptonote_utils.spec.js
@@ -1,8 +1,6 @@
 "use strict";
 const mymonero = require("../");
 const assert = require("assert");
-const JSBigInt = require("../cryptonote_utils/biginteger").BigInteger;
-const mnemonic = require("../cryptonote_utils/mnemonic");
 
 var public_key =
 	"904e49462268d771cc1649084c35aa1296bfb214880fe2e7f373620a3e2ba597";
@@ -10,297 +8,113 @@ var private_key =
 	"52aa4c69b93b780885c9d7f51e6fd5795904962c61a2e07437e130784846f70d";
 
 var nettype = mymonero.nettype_utils.network_type.MAINNET;
-const monero_utils = mymonero.monero_utils;
 
 describe("cryptonote_utils tests", function() {
-	it("borromean", () => {
-		function randomBit() {
-			// get random 32 bits in hex
-			const rand32bits = mnemonic.mn_random(32);
-			// take 4 bits "nibble" and convert to binary
-			// then take last index
-			return monero_utils.padLeft(
-				parseInt(rand32bits[0], 16).toString(2),
-				4,
-				0,
-			)[3];
-		}
-
-		//Tests for Borromean signatures
-		//#boro true one, false one, C != sum Ci, and one out of the range..
-		const N = 64;
-		let xv = [], // vector of secret keys, 1 per ring (nrings)
-			P1v = [], //key64, arr of commitments Ci
-			P2v = [], //key64
-			indi = []; // vector of secret indexes, 1 per ring (nrings), can be a string
-
-		for (let j = 0; j < N; j++) {
-			indi[j] = randomBit();
-
-			xv[j] = monero_utils.skGen();
-
-			if (+indi[j] === 0) {
-				P1v[j] = monero_utils.ge_scalarmult_base(xv[j]);
-			} else {
-				P1v[j] = monero_utils.ge_scalarmult_base(xv[j]); // calculate aG = xv[j].G
-				P1v[j] = monero_utils.ge_add(P1v[j], monero_utils.H2[j]); // calculate aG + H2
-			}
-
-			P2v[j] = monero_utils.ge_sub(P1v[j], monero_utils.H2[j]);
-		}
-		// #true one
-		let bb = monero_utils.genBorromean(xv, [P1v, P2v], indi, 2, N); /*?.*/
-		let valid = monero_utils.verifyBorromean(bb, P1v, P2v); /*?.*/
-		expect(valid).toBe(true);
-
-		//#false one
-		indi[3] = `${(+indi[3] + 1) % 2}`;
-		bb = monero_utils.genBorromean(xv, [P1v, P2v], indi, 2, N); /*?.*/
-		valid = monero_utils.verifyBorromean(bb, P1v, P2v); /*?.*/
-		expect(valid).toBe(false);
-
-		//#true one again
-		indi[3] = `${(+indi[3] + 1) % 2}`;
-		bb = monero_utils.genBorromean(xv, [P1v, P2v], indi, 2, N); /*?.*/
-		valid = monero_utils.verifyBorromean(bb, P1v, P2v); /*?.*/
-		expect(valid).toBe(true);
-
-		// #false one
-		bb = monero_utils.genBorromean(xv, [P2v, P1v], indi, 2, N); /*?.*/
-		valid = monero_utils.verifyBorromean(bb, P1v, P2v); /*?.*/
-		expect(valid).toBe(false);
-	});
-	it("ecdh_roundtrip", () => {
-		const test_amounts = [
-			new JSBigInt(1),
-			new JSBigInt(1),
-			new JSBigInt(2),
-			new JSBigInt(3),
-			new JSBigInt(4),
-			new JSBigInt(5),
-			new JSBigInt(10000),
-
-			new JSBigInt("10000000000000000000"),
-			new JSBigInt("10203040506070809000"),
-
-			new JSBigInt("123456789123456789"),
-		];
-
-		for (const amount of test_amounts) {
-			const k = monero_utils.skGen();
-			const scalar = monero_utils.skGen(); /*?*/
-			const amt = monero_utils.d2s(amount.toString());
-			const t0 = {
-				mask: scalar,
-				amount: amt,
-			};
-
-			// both are strings so we can shallow copy
-			let t1 = { ...t0 };
-
-			t1 = monero_utils.encode_rct_ecdh(t1, k);
-
-			t1 = monero_utils.decode_rct_ecdh(t1, k);
-			expect(t1.mask).toEqual(t0.mask);
-			expect(t1.amount).toEqual(t0.amount);
-		}
+	it("is valid hex", function() {
+		var valid = mymonero.monero_utils.valid_hex(private_key);
+		assert.strictEqual(valid, true);
 	});
 
-	it("MG_sigs", () => {
-		function skvGen(len) {
-			let skVec = [];
-			for (let i = 0; i < len; i++) {
-				skVec.push(monero_utils.skGen());
-			}
-			return skVec;
-		}
-		//initializes a key matrix;
-		//first parameter is rows,
-		//second is columns
-		function keyMInit(rows, cols) {
-			let rv = [];
-			for (let i = 0; i < cols; i++) {
-				rv.push([]);
-			}
-			return rv;
-		}
-		let j = 0;
-
-		//Tests for MG Sigs
-		//#MG sig: true one
-		let N = 3; // cols
-		let R = 2; // rows
-
-		let xtmp = skvGen(R);
-		let xm = keyMInit(R, N); // = [[None]*N] #just used to generate test public keys
-		let sk = skvGen(R);
-
-		// [
-		// [pubkey1, commitment1],
-		// [pubkey2, commitment2],
-		// ...
-		// [pubkeyn, commitmentn]]
-		// // Gen creates a signature which proves that for some column in the keymatrix "pk"
-		//  the signer knows a secret key for each row in that column
-		let P = keyMInit(R, N); // = keyM[[None]*N] #stores the public keys;
-
-		let ind = 2;
-		let i = 0;
-
-		for (j = 0; j < R; j++) {
-			for (i = 0; i < N; i++) {
-				xm[i][j] = monero_utils.skGen();
-				P[i][j] = monero_utils.ge_scalarmult_base(xm[i][j]); // generate fake [pubkey, commit]
-			}
-		}
-
-		for (j = 0; j < R; j++) {
-			// our secret vector of [onetimesec, z]
-			sk[j] = xm[ind][j];
-		}
-
-		let message = monero_utils.identity();
-		let kimg = monero_utils.ge_scalarmult(
-			monero_utils.hashToPoint(P[ind][0]),
-			sk[0],
+	it("fast hash / keccak-256", function() {
+		var hash = mymonero.monero_utils.cn_fast_hash(
+			private_key,
+			private_key.length,
 		);
-		let rv = monero_utils.MLSAG_Gen(message, P, sk, kimg, ind);
-		let c = monero_utils.MLSAG_ver(message, P, rv, kimg);
-
-		expect(Number(c)).toEqual(0);
-
-		xtmp = skvGen(R);
-		xm = keyMInit(R, N); // = [[None]*N] #just used to generate test public keys
-		sk = skvGen(R);
-
-		for (j = 0; j < R; j++) {
-			for (i = 0; i < N; i++) {
-				xm[i][j] = monero_utils.skGen();
-				P[i][j] = monero_utils.ge_scalarmult_base(xm[i][j]); // generate fake [pubkey, commit]
-			}
-		}
-
-		sk[1] = skGen(); //assume we don't know one of the private keys..
-		kimg = monero_utils.ge_scalarmult(
-			monero_utils.hashToPoint(P[ind][0]),
-			sk[0],
+		assert.equal(
+			hash,
+			"64997ff54f0d82ee87d51e971a0329d4315481eaeb4ad2403c65d5843480c414",
 		);
-		rv = monero_utils.MLSAG_Gen(message, P, sk, kimg, ind);
-		c = monero_utils.MLSAG_ver(message, P, rv, kimg);
-
-		expect(Number(c)).toBeFalsy();
 	});
 
-	describe("old_tests", () => {
-		it("is valid hex", function() {
-			var valid = mymonero.monero_utils.valid_hex(private_key);
-			assert.strictEqual(valid, true);
-		});
+	it("generate key derivation", function() {
+		var derivation = mymonero.monero_utils.generate_key_derivation(
+			public_key,
+			private_key,
+		);
+		assert.equal(
+			derivation,
+			"591c749f1868c58f37ec3d2a9d2f08e7f98417ac4f8131e3a57c1fd71273ad00",
+		);
+	});
 
-		it("fast hash / keccak-256", function() {
-			var hash = mymonero.monero_utils.cn_fast_hash(
-				private_key,
-				private_key.length,
-			);
-			assert.equal(
-				hash,
-				"64997ff54f0d82ee87d51e971a0329d4315481eaeb4ad2403c65d5843480c414",
-			);
-		});
+	it("decode mainnet primary address", function() {
+		var decoded = mymonero.monero_utils.decode_address(
+			"49qwWM9y7j1fvaBK684Y5sMbN8MZ3XwDLcSaqcKwjh5W9kn9qFigPBNBwzdq6TCAm2gKxQWrdZuEZQBMjQodi9cNRHuCbTr",
+			nettype,
+		);
+		var expected = {
+			spend:
+				"d8f1e81ecbe25ce8b596d426fb02fe7b1d4bb8d14c06b3d3e371a60eeea99534",
+			view:
+				"576f0e61e250d941746ed147f602b5eb1ea250ca385b028a935e166e18f74bd7",
+		};
+		assert.deepEqual(decoded, expected);
+	});
 
-		it("generate key derivation", function() {
-			var derivation = mymonero.monero_utils.generate_key_derivation(
-				public_key,
-				private_key,
-			);
-			assert.equal(
-				derivation,
-				"591c749f1868c58f37ec3d2a9d2f08e7f98417ac4f8131e3a57c1fd71273ad00",
-			);
-		});
+	it("decode mainnet integrated address", function() {
+		var decoded = mymonero.monero_utils.decode_address(
+			"4KYcX9yTizXfvaBK684Y5sMbN8MZ3XwDLcSaqcKwjh5W9kn9qFigPBNBwzdq6TCAm2gKxQWrdZuEZQBMjQodi9cNd3mZpgrjXBKMx9ee7c",
+			nettype,
+		);
+		var expected = {
+			spend:
+				"d8f1e81ecbe25ce8b596d426fb02fe7b1d4bb8d14c06b3d3e371a60eeea99534",
+			view:
+				"576f0e61e250d941746ed147f602b5eb1ea250ca385b028a935e166e18f74bd7",
+			intPaymentId: "83eab71fbee84eb9",
+		};
+		assert.deepEqual(decoded, expected);
+	});
 
-		it("decode mainnet primary address", function() {
-			var decoded = mymonero.monero_utils.decode_address(
-				"49qwWM9y7j1fvaBK684Y5sMbN8MZ3XwDLcSaqcKwjh5W9kn9qFigPBNBwzdq6TCAm2gKxQWrdZuEZQBMjQodi9cNRHuCbTr",
-				nettype,
-			);
-			var expected = {
-				spend:
-					"d8f1e81ecbe25ce8b596d426fb02fe7b1d4bb8d14c06b3d3e371a60eeea99534",
-				view:
-					"576f0e61e250d941746ed147f602b5eb1ea250ca385b028a935e166e18f74bd7",
-			};
-			assert.deepEqual(decoded, expected);
-		});
+	it("hash_to_scalar", function() {
+		var scalar = mymonero.monero_utils.hash_to_scalar(private_key);
+		assert.equal(
+			scalar,
+			"77c5899835aa6f96b13827f43b094abf315481eaeb4ad2403c65d5843480c404",
+		);
+	});
 
-		it("decode mainnet integrated address", function() {
-			var decoded = mymonero.monero_utils.decode_address(
-				"4KYcX9yTizXfvaBK684Y5sMbN8MZ3XwDLcSaqcKwjh5W9kn9qFigPBNBwzdq6TCAm2gKxQWrdZuEZQBMjQodi9cNd3mZpgrjXBKMx9ee7c",
-				nettype,
-			);
-			var expected = {
-				spend:
-					"d8f1e81ecbe25ce8b596d426fb02fe7b1d4bb8d14c06b3d3e371a60eeea99534",
-				view:
-					"576f0e61e250d941746ed147f602b5eb1ea250ca385b028a935e166e18f74bd7",
-				intPaymentId: "83eab71fbee84eb9",
-			};
-			assert.deepEqual(decoded, expected);
-		});
+	it("derivation_to_scalar", function() {
+		var derivation = mymonero.monero_utils.generate_key_derivation(
+			public_key,
+			private_key,
+		);
+		var scalar = mymonero.monero_utils.derivation_to_scalar(derivation, 1);
+		assert.equal(
+			scalar,
+			"201ce3c258e09eeb6132ec266d24ee1ca957828f384ce052d5bc217c2c55160d",
+		);
+	});
 
-		it("hash_to_scalar", function() {
-			var scalar = mymonero.monero_utils.hash_to_scalar(private_key);
-			assert.equal(
-				scalar,
-				"77c5899835aa6f96b13827f43b094abf315481eaeb4ad2403c65d5843480c404",
-			);
-		});
+	it("derive public key", function() {
+		var derivation = mymonero.monero_utils.generate_key_derivation(
+			public_key,
+			private_key,
+		);
+		var output_key = mymonero.monero_utils.derive_public_key(
+			derivation,
+			1,
+			public_key,
+		);
+		assert.equal(
+			output_key,
+			"da26518ddb54cde24ccfc59f36df13bbe9bdfcb4ef1b223d9ab7bef0a50c8be3",
+		);
+	});
 
-		it("derivation_to_scalar", function() {
-			var derivation = mymonero.monero_utils.generate_key_derivation(
-				public_key,
-				private_key,
-			);
-			var scalar = mymonero.monero_utils.derivation_to_scalar(
-				derivation,
-				1,
-			);
-			assert.equal(
-				scalar,
-				"201ce3c258e09eeb6132ec266d24ee1ca957828f384ce052d5bc217c2c55160d",
-			);
-		});
-
-		it("derive public key", function() {
-			var derivation = mymonero.monero_utils.generate_key_derivation(
-				public_key,
-				private_key,
-			);
-			var output_key = mymonero.monero_utils.derive_public_key(
-				derivation,
-				1,
-				public_key,
-			);
-			assert.equal(
-				output_key,
-				"da26518ddb54cde24ccfc59f36df13bbe9bdfcb4ef1b223d9ab7bef0a50c8be3",
-			);
-		});
-
-		it("derive subaddress public key", function() {
-			var derivation = mymonero.monero_utils.generate_key_derivation(
-				public_key,
-				private_key,
-			);
-			var subaddress_public_key = mymonero.monero_utils.derive_subaddress_public_key(
-				public_key,
-				derivation,
-				1,
-			);
-			assert.equal(
-				subaddress_public_key,
-				"dfc9e4a0039e913204c1c0f78e954a7ec7ce291d8ffe88265632f0da9d8de1be",
-			);
-		});
+	it("derive subaddress public key", function() {
+		var derivation = mymonero.monero_utils.generate_key_derivation(
+			public_key,
+			private_key,
+		);
+		var subaddress_public_key = mymonero.monero_utils.derive_subaddress_public_key(
+			public_key,
+			derivation,
+			1,
+		);
+		assert.equal(
+			subaddress_public_key,
+			"dfc9e4a0039e913204c1c0f78e954a7ec7ce291d8ffe88265632f0da9d8de1be",
+		);
 	});
 });

--- a/tests/cryptonote_utils.spec.js
+++ b/tests/cryptonote_utils.spec.js
@@ -1,6 +1,7 @@
 "use strict";
-const mymonero = require("mymonero-core-js");
+const mymonero = require("../");
 const assert = require("assert");
+const JSBigInt = require("../cryptonote_utils/biginteger").BigInteger;
 
 var public_key =
 	"904e49462268d771cc1649084c35aa1296bfb214880fe2e7f373620a3e2ba597";
@@ -8,113 +9,157 @@ var private_key =
 	"52aa4c69b93b780885c9d7f51e6fd5795904962c61a2e07437e130784846f70d";
 
 var nettype = mymonero.nettype_utils.network_type.MAINNET;
+const monero_utils = mymonero.monero_utils;
 
 describe("cryptonote_utils tests", function() {
-	it("is valid hex", function() {
-		var valid = mymonero.monero_utils.valid_hex(private_key);
-		assert.strictEqual(valid, true);
+	it("ecdh_roundtrip", () => {
+		const test_amounts = [
+			new JSBigInt(1),
+			new JSBigInt(1),
+			new JSBigInt(2),
+			new JSBigInt(3),
+			new JSBigInt(4),
+			new JSBigInt(5),
+			new JSBigInt(10000),
+
+			new JSBigInt("10000000000000000000"),
+			new JSBigInt("10203040506070809000"),
+
+			new JSBigInt("123456789123456789"),
+		];
+
+		console.log(monero_utils.random_keypair());
+
+		for (const amount of test_amounts) {
+			const k = monero_utils.random_scalar();
+			const scalar = monero_utils.random_scalar(); /*?*/
+			const amt = monero_utils.d2s(amount.toString());
+			const t0 = {
+				mask: scalar,
+				amount: amt,
+			};
+
+			// both are strings so we can shallow copy
+			let t1 = { ...t0 };
+
+			t1 = monero_utils.encode_rct_ecdh(t1, k);
+
+			t1 = monero_utils.decode_rct_ecdh(t1, k);
+			expect(t1.mask).toEqual(t0.mask);
+			expect(t1.amount).toEqual(t0.amount);
+		}
 	});
 
-	it("fast hash / keccak-256", function() {
-		var hash = mymonero.monero_utils.cn_fast_hash(
-			private_key,
-			private_key.length,
-		);
-		assert.equal(
-			hash,
-			"64997ff54f0d82ee87d51e971a0329d4315481eaeb4ad2403c65d5843480c414",
-		);
-	});
+	describe("old_tests", () => {
+		it("is valid hex", function() {
+			var valid = mymonero.monero_utils.valid_hex(private_key);
+			assert.strictEqual(valid, true);
+		});
 
-	it("generate key derivation", function() {
-		var derivation = mymonero.monero_utils.generate_key_derivation(
-			public_key,
-			private_key,
-		);
-		assert.equal(
-			derivation,
-			"591c749f1868c58f37ec3d2a9d2f08e7f98417ac4f8131e3a57c1fd71273ad00",
-		);
-	});
+		it("fast hash / keccak-256", function() {
+			var hash = mymonero.monero_utils.cn_fast_hash(
+				private_key,
+				private_key.length,
+			);
+			assert.equal(
+				hash,
+				"64997ff54f0d82ee87d51e971a0329d4315481eaeb4ad2403c65d5843480c414",
+			);
+		});
 
-	it("decode mainnet primary address", function() {
-		var decoded = mymonero.monero_utils.decode_address(
-			"49qwWM9y7j1fvaBK684Y5sMbN8MZ3XwDLcSaqcKwjh5W9kn9qFigPBNBwzdq6TCAm2gKxQWrdZuEZQBMjQodi9cNRHuCbTr",
-			nettype,
-		);
-		var expected = {
-			spend:
-				"d8f1e81ecbe25ce8b596d426fb02fe7b1d4bb8d14c06b3d3e371a60eeea99534",
-			view:
-				"576f0e61e250d941746ed147f602b5eb1ea250ca385b028a935e166e18f74bd7",
-		};
-		assert.deepEqual(decoded, expected);
-	});
+		it("generate key derivation", function() {
+			var derivation = mymonero.monero_utils.generate_key_derivation(
+				public_key,
+				private_key,
+			);
+			assert.equal(
+				derivation,
+				"591c749f1868c58f37ec3d2a9d2f08e7f98417ac4f8131e3a57c1fd71273ad00",
+			);
+		});
 
-	it("decode mainnet integrated address", function() {
-		var decoded = mymonero.monero_utils.decode_address(
-			"4KYcX9yTizXfvaBK684Y5sMbN8MZ3XwDLcSaqcKwjh5W9kn9qFigPBNBwzdq6TCAm2gKxQWrdZuEZQBMjQodi9cNd3mZpgrjXBKMx9ee7c",
-			nettype,
-		);
-		var expected = {
-			spend:
-				"d8f1e81ecbe25ce8b596d426fb02fe7b1d4bb8d14c06b3d3e371a60eeea99534",
-			view:
-				"576f0e61e250d941746ed147f602b5eb1ea250ca385b028a935e166e18f74bd7",
-			intPaymentId: "83eab71fbee84eb9",
-		};
-		assert.deepEqual(decoded, expected);
-	});
+		it("decode mainnet primary address", function() {
+			var decoded = mymonero.monero_utils.decode_address(
+				"49qwWM9y7j1fvaBK684Y5sMbN8MZ3XwDLcSaqcKwjh5W9kn9qFigPBNBwzdq6TCAm2gKxQWrdZuEZQBMjQodi9cNRHuCbTr",
+				nettype,
+			);
+			var expected = {
+				spend:
+					"d8f1e81ecbe25ce8b596d426fb02fe7b1d4bb8d14c06b3d3e371a60eeea99534",
+				view:
+					"576f0e61e250d941746ed147f602b5eb1ea250ca385b028a935e166e18f74bd7",
+			};
+			assert.deepEqual(decoded, expected);
+		});
 
-	it("hash_to_scalar", function() {
-		var scalar = mymonero.monero_utils.hash_to_scalar(private_key);
-		assert.equal(
-			scalar,
-			"77c5899835aa6f96b13827f43b094abf315481eaeb4ad2403c65d5843480c404",
-		);
-	});
+		it("decode mainnet integrated address", function() {
+			var decoded = mymonero.monero_utils.decode_address(
+				"4KYcX9yTizXfvaBK684Y5sMbN8MZ3XwDLcSaqcKwjh5W9kn9qFigPBNBwzdq6TCAm2gKxQWrdZuEZQBMjQodi9cNd3mZpgrjXBKMx9ee7c",
+				nettype,
+			);
+			var expected = {
+				spend:
+					"d8f1e81ecbe25ce8b596d426fb02fe7b1d4bb8d14c06b3d3e371a60eeea99534",
+				view:
+					"576f0e61e250d941746ed147f602b5eb1ea250ca385b028a935e166e18f74bd7",
+				intPaymentId: "83eab71fbee84eb9",
+			};
+			assert.deepEqual(decoded, expected);
+		});
 
-	it("derivation_to_scalar", function() {
-		var derivation = mymonero.monero_utils.generate_key_derivation(
-			public_key,
-			private_key,
-		);
-		var scalar = mymonero.monero_utils.derivation_to_scalar(derivation, 1);
-		assert.equal(
-			scalar,
-			"201ce3c258e09eeb6132ec266d24ee1ca957828f384ce052d5bc217c2c55160d",
-		);
-	});
+		it("hash_to_scalar", function() {
+			var scalar = mymonero.monero_utils.hash_to_scalar(private_key);
+			assert.equal(
+				scalar,
+				"77c5899835aa6f96b13827f43b094abf315481eaeb4ad2403c65d5843480c404",
+			);
+		});
 
-	it("derive public key", function() {
-		var derivation = mymonero.monero_utils.generate_key_derivation(
-			public_key,
-			private_key,
-		);
-		var output_key = mymonero.monero_utils.derive_public_key(
-			derivation,
-			1,
-			public_key,
-		);
-		assert.equal(
-			output_key,
-			"da26518ddb54cde24ccfc59f36df13bbe9bdfcb4ef1b223d9ab7bef0a50c8be3",
-		);
-	});
+		it("derivation_to_scalar", function() {
+			var derivation = mymonero.monero_utils.generate_key_derivation(
+				public_key,
+				private_key,
+			);
+			var scalar = mymonero.monero_utils.derivation_to_scalar(
+				derivation,
+				1,
+			);
+			assert.equal(
+				scalar,
+				"201ce3c258e09eeb6132ec266d24ee1ca957828f384ce052d5bc217c2c55160d",
+			);
+		});
 
-	it("derive subaddress public key", function() {
-		var derivation = mymonero.monero_utils.generate_key_derivation(
-			public_key,
-			private_key,
-		);
-		var subaddress_public_key = mymonero.monero_utils.derive_subaddress_public_key(
-			public_key,
-			derivation,
-			1,
-		);
-		assert.equal(
-			subaddress_public_key,
-			"dfc9e4a0039e913204c1c0f78e954a7ec7ce291d8ffe88265632f0da9d8de1be",
-		);
+		it("derive public key", function() {
+			var derivation = mymonero.monero_utils.generate_key_derivation(
+				public_key,
+				private_key,
+			);
+			var output_key = mymonero.monero_utils.derive_public_key(
+				derivation,
+				1,
+				public_key,
+			);
+			assert.equal(
+				output_key,
+				"da26518ddb54cde24ccfc59f36df13bbe9bdfcb4ef1b223d9ab7bef0a50c8be3",
+			);
+		});
+
+		it("derive subaddress public key", function() {
+			var derivation = mymonero.monero_utils.generate_key_derivation(
+				public_key,
+				private_key,
+			);
+			var subaddress_public_key = mymonero.monero_utils.derive_subaddress_public_key(
+				public_key,
+				derivation,
+				1,
+			);
+			assert.equal(
+				subaddress_public_key,
+				"dfc9e4a0039e913204c1c0f78e954a7ec7ce291d8ffe88265632f0da9d8de1be",
+			);
+		});
 	});
 });

--- a/tests/cryptonote_utils.spec.js
+++ b/tests/cryptonote_utils.spec.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 "use strict";
 const mymonero = require("../");
 const assert = require("assert");

--- a/tests/cryptonote_utils.spec.js
+++ b/tests/cryptonote_utils.spec.js
@@ -28,8 +28,6 @@ describe("cryptonote_utils tests", function() {
 			new JSBigInt("123456789123456789"),
 		];
 
-		console.log(monero_utils.random_keypair());
-
 		for (const amount of test_amounts) {
 			const k = monero_utils.random_scalar();
 			const scalar = monero_utils.random_scalar(); /*?*/

--- a/tests/ecdh.spec.js
+++ b/tests/ecdh.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/tests/ecdh.spec.js
+++ b/tests/ecdh.spec.js
@@ -1,0 +1,38 @@
+const JSBigInt = require("../cryptonote_utils/biginteger").BigInteger;
+const monero_utils = require("../").monero_utils;
+
+it("ecdh_roundtrip", () => {
+	const test_amounts = [
+		new JSBigInt(1),
+		new JSBigInt(1),
+		new JSBigInt(2),
+		new JSBigInt(3),
+		new JSBigInt(4),
+		new JSBigInt(5),
+		new JSBigInt(10000),
+
+		new JSBigInt("10000000000000000000"),
+		new JSBigInt("10203040506070809000"),
+
+		new JSBigInt("123456789123456789"),
+	];
+
+	for (const amount of test_amounts) {
+		const k = monero_utils.skGen();
+		const scalar = monero_utils.skGen(); /*?*/
+		const amt = monero_utils.d2s(amount.toString());
+		const t0 = {
+			mask: scalar,
+			amount: amt,
+		};
+
+		// both are strings so we can shallow copy
+		let t1 = { ...t0 };
+
+		t1 = monero_utils.encode_rct_ecdh(t1, k);
+
+		t1 = monero_utils.decode_rct_ecdh(t1, k);
+		expect(t1.mask).toEqual(t0.mask);
+		expect(t1.amount).toEqual(t0.amount);
+	}
+});

--- a/tests/ecdh.spec.js
+++ b/tests/ecdh.spec.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 const JSBigInt = require("../cryptonote_utils/biginteger").BigInteger;
 const monero_utils = require("../").monero_utils;
 

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017, MyMonero.com
+// Copyright (c) 2014-2018, MyMonero.com
 //
 // All rights reserved.
 //

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,26 @@
+module.exports = function(wallaby) {
+	process.env.NODE_ENV = "development";
+
+	return {
+		name: "mymonero-core-js",
+		files: [
+			"cryptonote_utils/**/*.js",
+			"hostAPI/**/*.js",
+			"monero_utils/**/*.js",
+			"index.js",
+		],
+
+		filesWithNoCoverageCalculated: [
+			"cryptonote_utils/nacl-fast-cn.js",
+			"cryptonote_utils/biginteger.js",
+			"cryptonote_utils/sha3.js",
+			"cryptonote_utils/cryptonote_crypto_EMSCRIPTEN.js",
+		],
+
+		tests: ["./tests/**/*spec.js"],
+
+		testFramework: "jest",
+
+		env: { type: "node", runner: "node" },
+	};
+};

--- a/wallaby.js
+++ b/wallaby.js
@@ -8,6 +8,7 @@ module.exports = function(wallaby) {
 			"hostAPI/**/*.js",
 			"monero_utils/**/*.js",
 			"index.js",
+			"tests/borromean/test_parameters.js",
 		],
 
 		filesWithNoCoverageCalculated: [

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,3 +1,31 @@
+// Copyright (c) 2014-2017, MyMonero.com
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//	conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//	of conditions and the following disclaimer in the documentation and/or other
+//	materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//	used to endorse or promote products derived from this software without specific
+//	prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 module.exports = function(wallaby) {
 	process.env.NODE_ENV = "development";
 


### PR DESCRIPTION
### Changes:
- Add wallaby support for IDE integration
- Expose d2s/d2h functions for testing ecdh{Encode,Decode} functions
- Configure Jest to use node environment so that window.crypto checks dont happen 
- Add ecdh{Encode,Decode} function tests 
- Add genBorromean tests, add verifyBorromean function
- Add MLSAG_gen tests, add MLSAG_ver function
- Coverage increased from 15% to 30%