### PR TITLE
Create tx with pre-generated txkey

### DIFF
--- a/cryptonote_utils/cryptonote_utils.js
+++ b/cryptonote_utils/cryptonote_utils.js
@@ -2540,9 +2540,10 @@ var cnUtil = function(currencyConfig) {
 		unlock_time,
 		rct,
 		nettype,
+		txkey
 	) {
 		//we move payment ID stuff here, because we need txkey to encrypt
-		var txkey = this.random_keypair();
+		if (!txkey) txkey = this.random_keypair();
 		console.log(txkey);
 		var extra = "";
 		if (payment_id) {
@@ -2776,6 +2777,7 @@ var cnUtil = function(currencyConfig) {
 		unlock_time,
 		rct,
 		nettype,
+		txkey
 	) {
 		unlock_time = unlock_time || 0;
 		mix_outs = mix_outs || [];
@@ -2932,6 +2934,7 @@ var cnUtil = function(currencyConfig) {
 			unlock_time,
 			rct,
 			nettype,
+			txkey
 		);
 	};
 


### PR DESCRIPTION
Since the tx private key is irrecoverable, I think it makes sense to provide some method of storing it. This PR adds an optional parameter to the `create_transaction()` and `construct_tx()` functions called `txkey`, so that you can generate and save the txkey, and use it to generate a transaction.

I'm unsure about how the branches work on this repo, so let me know if it's better to do a PR against `develop`