### PR TITLE
Create tx with pre-generated txkey

### DIFF
--- a/cryptonote_utils/cryptonote_utils.js
+++ b/cryptonote_utils/cryptonote_utils.js
@@ -2759,7 +2759,7 @@ var cnUtil = function(currencyConfig) {
 			);
 		}
 		console.log(tx);
-		return tx;
+		return { tx, txkey };
 	};
 
 	this.create_transaction = function(

--- a/monero_utils/monero_sendingFunds_utils.js
+++ b/monero_utils/monero_sendingFunds_utils.js
@@ -652,7 +652,7 @@ function SendFunds(
 				console.log("Decomposed destinations:");
 				monero_utils.printDsts(splitDestinations);
 				//
-				signedTx = monero_utils.create_transaction(
+				var fullTx = monero_utils.create_transaction(
 					wallet__public_keys,
 					wallet__private_keys,
 					splitDestinations,
@@ -667,6 +667,7 @@ function SendFunds(
 					isRingCT,
 					nettype,
 				);
+				var signedTx = fullTx.tx;
 			} catch (e) {
 				var errStr;
 				if (e) {


### PR DESCRIPTION
Since the tx private key is irrecoverable, I think it makes sense to provide some method of storing it. This PR adds an optional parameter to the `create_transaction()` and `construct_tx()` functions called `txkey`, so that you can generate and save the txkey, and use it to generate a transaction.

I'm unsure about how the branches work on this repo, so let me know if it's better to do a PR against `develop`

#48 against the `develop` branch