### PR TITLE
Fixed issue with deprecated emscripten linker flag BINARYEN_METHOD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ set(
 -Os \
 --separate-asm \
 -s AGGRESSIVE_VARIABLE_ELIMINATION=1 \
--s \"BINARYEN_METHOD='asmjs'\" \
 -s ALLOW_MEMORY_GROWTH=0 \
 --memory-init-file 0 \
 "
@@ -174,7 +173,6 @@ set(
     "${EMCC_LINKER_FLAGS___BASE} \
 -s WASM=1 \
 -Oz \
--s \"BINARYEN_METHOD='native-wasm'\" \
 -s ALLOW_MEMORY_GROWTH=1 \
 --post-js ${CMAKE_CURRENT_LIST_DIR}/src/module-post.js \
 "


### PR DESCRIPTION
Emscripten has deprecated their linker flag 'BINARYEN_METHOD' and mentioned that in the changelog:
v1.38.23: 01/10/2019
Remove BINARYEN_METHOD: no more support for interpret modes, and if you want non-wasm, use WASM=0.

It was simply removed from CMaeLists.txt file as it already has 'WASM=0' for asmjs and 'WASM=1' for wasm.